### PR TITLE
update integration docs

### DIFF
--- a/docs/zh/06-agent-integration/02-tracing/03-opentelemetry.md
+++ b/docs/zh/06-agent-integration/02-tracing/03-opentelemetry.md
@@ -112,6 +112,26 @@ otlphttp:
     enabled: true
 ```
 
+同时，为了确保 Span 发送侧的 IP 传递到 DeepFlow 中，需要增加如下配置：
+```yaml
+processors:
+  k8sattributes:
+  resource:
+    attributes:
+    - key: app.host.ip
+      from_attribute: k8s.pod.ip
+      action: insert
+```
+
+最后，在 service.pipeline 中，对 `traces` 一节增加：
+```yaml
+service:
+  pipelines:
+    traces:
+      processors: [k8sattributes, resource] # 确保 k8sattributes processor 先被处理
+      exporters: [otlphttp]
+```
+
 # 配置 DeepFlow
 
 接下来我们需要开启 deepflow-agent 的数据接收服务。

--- a/docs/zh/06-agent-integration/02-tracing/04-skywalking.md
+++ b/docs/zh/06-agent-integration/02-tracing/04-skywalking.md
@@ -91,7 +91,9 @@ spec:
       targetPort: 11800
 ```
 
-最后，重启 otel-agent 完成应用更新：
+然后，检查应用中配置的 [SkyWalking OAP Server](https://skywalking.apache.org/docs/main/next/en/setup/backend/backend-setup/#requirements-and-default-settings) 的对接地址，并修改为 Otel Agent 的 Service 地址：`otel-agent.open-telemetry`，比如将环境变量 `SW_AGENT_COLLECTOR_BACKEND_SERVICES=oap-server:11800` 修改为 `SW_AGENT_COLLECTOR_BACKEND_SERVICES=otel-agent.open-telemetry:11800`。
+
+最后，重启 otel-agent 完成 otel-agent 更新：
 ```bash
 kubectl rollout restart -n open-telemetry daemonset/otel-agent
 ```

--- a/docs/zh/07-server-integration/01-query/02-promql.md
+++ b/docs/zh/07-server-integration/01-query/02-promql.md
@@ -5,15 +5,14 @@ permalink: /server-integration/query/promql
 
 # 简介
 
-DeepFlow 从 v6.2.1 开始支持 PromQL，目前实现了如下 Prometheus API：
+DeepFlow 从 v6.2.1 开始支持 PromQL，目前实现了如下 Prometheus API，通过 HTTP 直接调用可参考 [Prometheus 接口定义](https://prometheus.io/docs/prometheus/latest/querying/api/#expression-queries)：
 
- Http Method | Path                                 | Description
--------------|--------------------------------------|----------------------
- GET/POST    | /prom/api/v1/query                   | 查询一个时间点的数据
- GET/POST    | /prom/api/v1/query_range             | 查询一个时间范围的数据
- GET         | /prom/api/v1/label/:labelName/values | 获取一个指标的所有标签
- GET/POST    | /prom/api/v1/series                  | 获取所有时序
-
+ Http Method | Path                                 | Prometheus API                    | Description
+-------------|--------------------------------------|-----------------------------------|----------------------
+ GET/POST    | /prom/api/v1/query                   | /api/v1/query                     | 查询一个时间点的数据
+ GET/POST    | /prom/api/v1/query_range             | /api/v1/query_range               | 查询一个时间范围的数据
+ GET         | /prom/api/v1/label/:labelName/values | /api/v1/label/<label_name>/values | 获取一个指标的所有标签
+ GET/POST    | /prom/api/v1/series                  | /api/v1/series                    | 获取所有时序
 
 ## DeepFlow 指标定义
 


### PR DESCRIPTION
Lots of community users said `otel` / `skywalking` / `prometheus` integration usage is not clear in our docs.
Updates:
- clarify how to pass `IP` from otel to deepflow by configuration otel config map;
- add SkyWalking Oap-Server integration usage.
- add Prometheus api usage link in Prometheus docs.