### PR TITLE
update docs

### DIFF
--- a/docs/zh/06-agent-integration/02-tracing/03-opentelemetry.md
+++ b/docs/zh/06-agent-integration/02-tracing/03-opentelemetry.md
@@ -102,10 +102,10 @@ kubectl get cm -n open-telemetry otel-agent-conf -o custom-columns=DATA:.data | 
     grep -A 5 otlphttp:
 ```
 
-deepflow-agent 使用 HostNetWork 监听端口接收 trace，默认端口为 38086，将 otel-agent 的配置进行修改：
+deepflow-agent 使用 ClusterIP Service 接收 trace，将 otel-agent 的配置进行修改：
 ```yaml
 otlphttp:
-  traces_endpoint: "http://${HOST_IP}:38086/api/v1/otel/trace"
+  traces_endpoint: "http://deepflow-agent.deepflow/api/v1/otel/trace"
   tls:
     insecure: true
   retry_on_failure:


### PR DESCRIPTION
due to deepflow agent no longer use `hostnetwork` after v6.3.5, update service host integration way