### PR TITLE
更新 deepfliw-ctl 使用方式与 docker 部署时存在问题 

### DIFF
--- a/docs/zh/02-ce-install/02-all-in-one.md
+++ b/docs/zh/02-ce-install/02-all-in-one.md
@@ -106,6 +106,11 @@ Grafana auth: admin:deepflow
 
 # 使用 Docker Compose 部署
 
+我们不推荐使用 Docker 部署 DeepFlow Server 端，具体原因如下：
+
+1. Server 端依赖  K8s 的 [lease](https://kubernetes.io/zh-cn/docs/concepts/architecture/leases/) 进行选主，通过多副本实现高可用性。而 Docker 环境缺乏 K8s 的这一机制，导致 Server 端仅能以单副本模式运行。在 Agent 节点数量较多或数据采集量较大的场景下，单副本实例可能因资源瓶颈而无法承载高并发的数据量。
+2. 当 Server 端以单副本形式部署时，配套的 ClickHouse 只能采用单切片形式部署，否则会导致数据写入不均衡，这在一定程度上限制了数据的查询速度。
+
 ## 准备工作
 
 ### 资源需求
@@ -161,18 +166,15 @@ docker compose -f deepflow-docker-compose/docker-compose.yaml up -d
 
 ## 访问 Grafana 页面
 
-使用 Docke Compose 部署的 DeepFlow Grafana 端口为 3000，用户密码为 admin:deepflow。
+通过 docker compose 部署后，将浏览器指向 `http://<$NODE_IP_FOR_DEEPFLOW>:3000` 即可登录 Grafana 控制台
 
-例如机器 IP 为 10.1.2.3， 则 Grafana 访问 URL 为 http://10.1.2.3:3000
-
-## 限制
-
-- 该部署模式下 deepflow-server、clickhouse 均不支持水平扩展。
-- 由于 deepflow-server 的一些能力依赖 Kubernetes，docker-compose 部署模式下无法监控云服务器，可参考 [监控传统服务器](./legacy-host) 对云主机进行监控。
+默认凭据：
+- 用户名：admin
+- 密码：deepflow
 
 # 下载 deepflow-ctl
 
-deepflow-ctl 是管理 DeepFlow 的一个命令行工具，建议下载至 deepflow-server 所在的 K8s Node 上，用于后续使用：
+deepflow-ctl 是 DeepFlow 的命令行管理工具，建议部署至 deepflow-server 所在的 K8s Node 上，以便后续用于 Agent [组配置管理](../best-practice/agent-advanced-config.md)及其他运维操作：
 
 ```bash
 # 与当前 server 版本同步即可

--- a/docs/zh/04-best-practice/01-agent-advanced-config.md
+++ b/docs/zh/04-best-practice/01-agent-advanced-config.md
@@ -7,7 +7,7 @@ permalink: /best-practice/agent-advanced-config/
 
 DeepFlow 通过声明式 API 对所有 agent 进行统一管控，而 agent 的数据采集配置由 deepflow-server 根据 agent-group-config 内容统一下发至对应 agent-group 内的 agent。
 
-agent-group 用于管理一组 agent 的配置，通过在 agent [配置文件](https://github.com/deepflowio/deepflow/blob/main/agent/config/deepflow-agent.yaml)（K8s ConfigMap 或 `/etc/deepflow-agent.yaml`）中指定 `vtap-group-id-request` 来声明归属的 agent-group（未指定时默认使用 [Default](https://github.com/deepflowio/deepflow/blob/main/server/agent_config/template.yaml) 配置），最终通过 agent-group ID 实现 agent、agent-group、agent-group-config 三者的关联。
+agent-group 用于管理一组 agent 的配置，通过在 agent [配置文件](https://github.com/deepflowio/deepflow/blob/main/agent/config/deepflow-agent.yaml)（K8s ConfigMap 或 `/etc/deepflow-agent.yaml`）中指定 `vtap-group-id-request` 来声明归属的 agent-group（未指定时默认使用 [Default](../configuration/agent/) 配置），最终通过 agent-group-id 实现 agent、agent-group、agent-group-config 三者的关联。
 
 ## agent-group 常用操作
 
@@ -23,7 +23,7 @@ deepflow-ctl agent-group list
 deepflow-ctl agent-group create your-agent-group
 ```
 
-获取创建的 agent-group ID:
+获取创建的 agent-group-id:
 
 ```bash
 deepflow-ctl agent-group list your-agent-group
@@ -31,7 +31,7 @@ deepflow-ctl agent-group list your-agent-group
 
 ## agent-group-config 常用操作
 
-参考上述 agent-group-config [默认配置](https://github.com/deepflowio/deepflow/blob/main/server/agent_config/template.yaml)，摘取其中需要修改的部分输出至 `your-agent-group-config.yaml` 文件，例如：
+参考上述 agent-group-config [默认配置](../configuration/agent/)，摘取其中需要修改的部分输出至 `your-agent-group-config.yaml` 文件，例如：
 
 ```yaml
 global:
@@ -43,7 +43,7 @@ global:
 ### 创建 agent-group-config
 
 ```bash
-deepflow-ctl agent-group-config create <agent-group ID> -f your-agent-group-config.yaml
+deepflow-ctl agent-group-config create <agent-group-id> -f your-agent-group-config.yaml
 ```
 
 ### 获取 agent-group-config 列表
@@ -55,13 +55,13 @@ deepflow-ctl agent-group-config list
 ### 获取 agent-group-config 配置
 
 ```bash
-deepflow-ctl agent-group-config list <agent-group ID> -o yaml
+deepflow-ctl agent-group-config list <agent-group-id> -o yaml
 ```
 
 ### 更新 agent-group-config 配置
 
 ```bash
-deepflow-ctl agent-group-config update <agent-group ID> -f your-agent-group-config.yaml
+deepflow-ctl agent-group-config update <agent-group-id> -f your-agent-group-config.yaml
 ```
 
 ## 各配置项说明

--- a/docs/zh/04-best-practice/01-agent-advanced-config.md
+++ b/docs/zh/04-best-practice/01-agent-advanced-config.md
@@ -5,9 +5,9 @@ permalink: /best-practice/agent-advanced-config/
 
 # 简介
 
-DeepFlow Agent 高级配置。
+DeepFlow 通过声明式 API 对所有 agent 进行统一管控，而 agent 的数据采集配置由 deepflow-server 根据 agent-group-config 内容统一下发至对应 agent-group 内的 agent。
 
-DeepFlow 使用声明式 API 对所有 deepflow-agent 进行控制，几乎所有的 deepflow-agent 配置均通过 deepflow-server 下发。在 DeepFlow 中，agent-group 为管理一组 deepflow-agent 配置的组。我们可以在 deepflow-agent 本地配置文件（K8s ConfigMap、Host 上的 deepflow-agent.yaml）中指定 `vtap-group-id-request` 来声明希望加入的组，也可直接在 deepflow-server 上配置每个 deepflow-agent 的所属组（且后者优先级更高）。agent-group-config 和 agent-group 一一对应，通过 agent-group ID 关联。
+agent-group 用于管理一组 agent 的配置，通过在 agent [配置文件](https://github.com/deepflowio/deepflow/blob/main/agent/config/deepflow-agent.yaml)（K8s ConfigMap 或 `/etc/deepflow-agent.yaml`）中指定 `vtap-group-id-request` 来声明归属的 agent-group（未指定时默认使用 [Default](https://github.com/deepflowio/deepflow/blob/main/server/agent_config/template.yaml) 配置），最终通过 agent-group ID 实现 agent、agent-group、agent-group-config 三者的关联。
 
 ## agent-group 常用操作
 
@@ -23,7 +23,7 @@ deepflow-ctl agent-group list
 deepflow-ctl agent-group create your-agent-group
 ```
 
-获取刚刚创建的 agent-group ID:
+获取创建的 agent-group ID:
 
 ```bash
 deepflow-ctl agent-group list your-agent-group
@@ -31,17 +31,19 @@ deepflow-ctl agent-group list your-agent-group
 
 ## agent-group-config 常用操作
 
-参考上述 agent 默认配置，摘取其中你想修改的部分，创建一个 `your-agent-group-config.yaml` 文件并填写 agent 配置参数，注意必须包含 `vtap_group_id`：
+参考上述 agent-group-config [默认配置](https://github.com/deepflowio/deepflow/blob/main/server/agent_config/template.yaml)，摘取其中需要修改的部分输出至 `your-agent-group-config.yaml` 文件，例如：
 
 ```yaml
-vtap_group_id: <Your-agent-group-ID>
-# write configurations here
+global:
+  limits:
+    max_millicpus: 1000
+    max_memory: 768
 ```
 
 ### 创建 agent-group-config
 
 ```bash
-deepflow-ctl agent-group-config create -f your-agent-group-config.yaml
+deepflow-ctl agent-group-config create <agent-group ID> -f your-agent-group-config.yaml
 ```
 
 ### 获取 agent-group-config 列表
@@ -53,24 +55,15 @@ deepflow-ctl agent-group-config list
 ### 获取 agent-group-config 配置
 
 ```bash
-deepflow-ctl agent-group-config list <Your-agent-group-ID> -o yaml
-```
-
-### 获取 agent-group-config 所有配置及其默认值
-
-```bash
-deepflow-ctl agent-group-config example
+deepflow-ctl agent-group-config list <agent-group ID> -o yaml
 ```
 
 ### 更新 agent-group-config 配置
 
 ```bash
-deepflow-ctl agent-group-config update -f your-agent-group-config.yaml
+deepflow-ctl agent-group-config update <agent-group ID> -f your-agent-group-config.yaml
 ```
 
-## 常用配置项
+## 各配置项说明
 
-- `max_memory`: agent 最大内存限制，默认值为 `768`，单位为 MB。
-- `thread_threshold`: agent 最大线程数量，默认值为 `500`。
-- `tap_interface_regex`: agent 采集网卡正则配置，默认值为 `^(tap.*|cali.*|veth.*|eth.*|en[ospx].*|lxc.*|lo)$`，agent 只需要采集 Pod 网卡和 Node/Host 物理网卡即可。
-- `platform_enabled`: agent 上报资源时使用， 用于 `agent-sync` 的 domain，一个 DeepFlow 平台只能有一个`agent-sync` 的 domain。
+具体可参考[配置手册](../configuration/agent/)，各参数均有详细说明与使用示例


### PR DESCRIPTION
1、前置不推荐使用 docker 部署的原因
2、去除 v6.5 deepflow-ctl 的使用方式（目前已接近 v7.0 LTS 版本，无需提供过旧的使用方式）